### PR TITLE
Update README.md to address Issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Displays both the **5-hour rolling window** and **7-day rolling window** with pr
    ```bash
    brew install --cask ubersicht
    ```
+   If you're install Übersicht for the first time, run it once to create the `widgets` folder where this widget will be installed.
 
 2. Download `claude-code-meter.jsx` into your Ubersicht widgets folder:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Displays both the **5-hour rolling window** and **7-day rolling window** with pr
    ```bash
    brew install --cask ubersicht
    ```
-   If you're install Übersicht for the first time, run it once to create the `widgets` folder where this widget will be installed.
+   If you're installing Übersicht for the first time, run it once to create the `widgets` folder where this widget will be installed.
 
 2. Download `claude-code-meter.jsx` into your Ubersicht widgets folder:
 


### PR DESCRIPTION
If Übersicht has been installed but not yet run, the widgets folder may not exist. Running it once will ensure it's been created.