### PR TITLE
fix: open Terminal window for re-authenticate button

### DIFF
--- a/claude-code-meter.jsx
+++ b/claude-code-meter.jsx
@@ -418,7 +418,7 @@ function ErrorDisplay({ errorType, httpCode, retryIn, dispatch }) {
           onClick={() => {
             dispatch({ type: "REAUTH" });
             run(
-              `osascript -e 'tell application "Terminal" to do script "CLAUDE=$(command -v claude 2>/dev/null || echo $HOME/.local/bin/claude); \\"$CLAUDE\\" auth login; exec $SHELL"' -e 'tell application "Terminal" to activate'`
+              `osascript -e 'tell application "Terminal" to do script "CLAUDE=$(command -v claude 2>/dev/null || echo $HOME/.local/bin/claude); \\"$CLAUDE\\" auth login" in front window' -e 'tell application "Terminal" to activate'`
             );
           }}
           style={{

--- a/claude-code-meter.jsx
+++ b/claude-code-meter.jsx
@@ -418,7 +418,7 @@ function ErrorDisplay({ errorType, httpCode, retryIn, dispatch }) {
           onClick={() => {
             dispatch({ type: "REAUTH" });
             run(
-              "$HOME/.local/bin/claude auth login 2>/dev/null || /usr/local/bin/claude auth login 2>/dev/null || /opt/homebrew/bin/claude auth login 2>/dev/null"
+              `osascript -e 'tell application "Terminal" to do script "CLAUDE=$(command -v claude 2>/dev/null || echo $HOME/.local/bin/claude); \\"$CLAUDE\\" auth login; exec $SHELL"' -e 'tell application "Terminal" to activate'`
             );
           }}
           style={{


### PR DESCRIPTION
## Problem

Clicking the **re-authenticate** button had no visible effect. The button called `claude auth login` via Übersicht's `run()`, which executes in a background shell with no TTY — so the OAuth browser flow could never start.

A first attempt opened a new Terminal window via osascript, but that caused `claude auth login` to fall back to the device flow (show a code in Chrome → paste it into Terminal), which was confusing and hard to use.

## Fix

Use `in front window` to run `claude auth login` in the **user's existing Terminal session**. This gives the command a proper interactive TTY so the OAuth flow completes seamlessly in the browser without any code to copy/paste.

```js
// Before
run("$HOME/.local/bin/claude auth login 2>/dev/null || ...");

// After
run(`osascript -e 'tell application "Terminal" to do script "CLAUDE=$(command -v claude 2>/dev/null || echo $HOME/.local/bin/claude); \\"$CLAUDE\\" auth login" in front window' -e 'tell application "Terminal" to activate'`);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)