### PR TITLE
Color bars by pace instead of absolute fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ The widget reads your OAuth token from the macOS Keychain (stored there by Claud
 
 The widget supports two display modes:
 
-- **Remaining** -- shows how much capacity is LEFT (bucket draining). Bars go from green (plenty) to amber (getting low) to red (nearly empty).
+- **Remaining** -- shows how much capacity is LEFT (bucket draining).
 
   ![Remaining mode](screenshot.png)
 
-- **Used** -- shows how much capacity is CONSUMED (counter filling). Bars go from amber (normal) to red (nearly full).
+- **Used** -- shows how much capacity is CONSUMED (counter filling).
 
   ![Used mode](screenshot-used.png)
+
+Bar color reflects **pace** (usage rate vs time elapsed in the window), not absolute fill: green when you're tracking under the sustainable rate, amber when on/above pace, red when burning through too fast. Below 10% remaining the bar is always red regardless of pace.
 
 **Click the mode badge** in the top-right corner of the widget header to toggle between modes. The label next to each percentage (`left` / `used`) always clarifies what the number means.
 

--- a/claude-code-meter.jsx
+++ b/claude-code-meter.jsx
@@ -177,20 +177,24 @@ function formatResetTime(resetAt) {
   return d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", timeZoneName: "short" });
 }
 
-function getBarColor(displayValue, mode) {
-  if (mode === "remaining") {
-    if (displayValue <= 10) return { bar: RED, dim: RED_DIM, glow: "#e0404060" };
-    if (displayValue <= 25) return { bar: AMBER, dim: AMBER_DIM, glow: AMBER_GLOW };
-    return { bar: GREEN, dim: GREEN_DIM, glow: GREEN_GLOW };
+// Color by pace (utilization rate vs time-elapsed rate in the window).
+// Low-fuel override: <=10% remaining is always red.
+// pace <= 0.8 green; 0.8 < pace <= 1.3 amber; > 1.3 red.
+function getBarColor(utilization, pace) {
+  const remaining = 100 - utilization;
+  if (remaining <= 10) return { bar: RED, dim: RED_DIM, glow: "#e0404060" };
+  if (pace == null) {
+    return { bar: AMBER, dim: AMBER_DIM, glow: AMBER_GLOW };
   }
-  if (displayValue >= 90) return { bar: RED, dim: RED_DIM, glow: "#e0404060" };
-  return { bar: AMBER, dim: AMBER_DIM, glow: AMBER_GLOW };
+  if (pace <= 0.8) return { bar: GREEN, dim: GREEN_DIM, glow: GREEN_GLOW };
+  if (pace <= 1.3) return { bar: AMBER, dim: AMBER_DIM, glow: AMBER_GLOW };
+  return { bar: RED, dim: RED_DIM, glow: "#e0404060" };
 }
 
-function UsageBar({ displayValue, mode, paceMarker, segments = 20 }) {
+function UsageBar({ displayValue, utilization, pace, paceMarker, segments = 20 }) {
   const filled = Math.round((displayValue / 100) * segments);
   const markerSeg = paceMarker != null ? Math.round((paceMarker / 100) * segments) : null;
-  const colors = getBarColor(displayValue, mode);
+  const colors = getBarColor(utilization, pace);
   // Each segment is 8px wide + 2px gap = 10px per segment
   const segWidth = 8;
   const segGap = 2;
@@ -253,12 +257,13 @@ function paceLabel(pace) {
 
 function UsageRow({ label, utilization, resetsAt, mode, windowMs }) {
   const displayValue = mode === "remaining" ? 100 - utilization : utilization;
-  const colors = getBarColor(displayValue, mode);
+  const paceInfo = calcPace(utilization, resetsAt, windowMs);
+  const pace = paceInfo ? paceInfo.pace : null;
+  const colors = getBarColor(utilization, pace);
   const { timeStr } = formatTimeLeft(resetsAt);
   const resetTime = formatResetTime(resetsAt);
   const suffix = mode === "remaining" ? "left" : "used";
 
-  const paceInfo = calcPace(utilization, resetsAt, windowMs);
   // In "remaining" mode, marker = time remaining %. In "used" mode, marker = time elapsed %.
   const paceMarker = paceInfo
     ? (mode === "remaining" ? paceInfo.timeRemainingPct : paceInfo.timeElapsedPct)
@@ -281,7 +286,7 @@ function UsageRow({ label, utilization, resetsAt, mode, windowMs }) {
           </span>
         </div>
       </div>
-      <UsageBar displayValue={displayValue} mode={mode} paceMarker={paceMarker} />
+      <UsageBar displayValue={displayValue} utilization={utilization} pace={pace} paceMarker={paceMarker} />
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "5px", fontSize: "10px", color: TEXT_DIM, fontFamily: "Menlo, monospace" }}>
         <span>resets {resetTime}</span>
         <span>{timeStr}</span>


### PR DESCRIPTION
## Summary
- Bar color now reflects burn rate (utilization vs time elapsed in the window) rather than absolute fill level
- Green = under pace (<= 0.8), amber = on/above pace (<= 1.3), red = high pace (> 1.3)
- Low-fuel override: <= 10% remaining is always red regardless of pace
- Same thresholds match the existing pace label/marker so the row tells one consistent story

## Why
With absolute-fill coloring, the bar could be amber at 40% remaining even when you're 80% through the window (i.e. tracking fine), or green at 50% remaining when you're only 20% through the window (i.e. burning way too fast). Pace-based coloring fixes both.

## Test plan
- [ ] Reload Ubersicht and confirm both 5h and 7d bars pick up colors from the existing pace numbers
- [ ] Sanity check: 5h bar near reset time with low utilization stays green; early in window with high utilization shifts to red
- [ ] Verify <=10% remaining still renders red even if pace is fine